### PR TITLE
If the identity is not managed, add to entity manager

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -67,7 +67,11 @@ class Module
 
                     $auth = $serviceManager->get($auditConfig->getAuthenticationService());
                     if ($auth->hasIdentity()) {
-                        $auditConfig->setUser($auth->getIdentity());
+                        if ($auditConfig->getEntityManager()->contains($auth->getIdentity())) {
+                            $auditConfig->setUser($auth->getIdentity());
+                        } else {
+                            $auditConfig->setUser($auditConfig->getEntityManager()->merge($auth->getIdentity()));
+                        }
                     }
 
                     return $auditConfig;


### PR DESCRIPTION
When using ZendAuthentication the user entity can be stored as the identity but when you fetch the identity in a future call the entity is just an object and not managed.  This PR will merge an unmanaged entity into the entity manager.
