### PR TITLE
 Support for Single Table Inheritance

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -32,6 +32,9 @@ class Module
         );
     }
 
+    /**
+     * @param MvcEvent $e
+     */
     public function onBootstrap(MvcEvent $e)
     {
         $moduleOptions = $e->getApplication()->getServiceManager()->get('auditModuleOptions');
@@ -39,11 +42,17 @@ class Module
         self::setModuleOptions($moduleOptions);
     }
 
+    /**
+     * @param ModuleOptions $moduleOptions
+     */
     public static function setModuleOptions(ModuleOptions $moduleOptions)
     {
         self::$moduleOptions = $moduleOptions;
     }
 
+    /**
+     * @return ModuleOptions
+     */
     public static function getModuleOptions()
     {
         return self::$moduleOptions;

--- a/config/audit.global.php.dist
+++ b/config/audit.global.php.dist
@@ -43,6 +43,8 @@ return array(
         'tableNameSuffix' => '_audit',
         'revisionTableName' => 'Revision',
         'revisionEntityTableName' => 'RevisionEntity',
+
+        'softDeletableInterfaceName' => '',
               
         /*
          * Entities to audit are specified as array keys

--- a/src/SoliantEntityAudit/EventListener/LogRevision.php
+++ b/src/SoliantEntityAudit/EventListener/LogRevision.php
@@ -161,10 +161,12 @@ class LogRevision implements EventSubscriber
         $auditEntities = array();
 
         $moduleOptions = \SoliantEntityAudit\Module::getModuleOptions();
-        if (!in_array(get_class($entity), array_keys($moduleOptions->getAuditedClassNames())))
+        $entityClass = $this->getEntityClass($entity);
+
+        if (!in_array($entityClass, array_keys($moduleOptions->getAuditedClassNames())))
             return array();
 
-        $auditEntityClass = 'SoliantEntityAudit\\Entity\\' . str_replace('\\', '_', get_class($entity));
+        $auditEntityClass = 'SoliantEntityAudit\\Entity\\' . str_replace('\\', '_', $entityClass);
         $auditEntity = new $auditEntityClass();
         $auditEntity->exchangeArray($this->getClassProperties($entity));
 
@@ -286,7 +288,7 @@ class LogRevision implements EventSubscriber
                     // Get current inverse revision entity
                     $revisionEntities = $entityManager->getRepository('SoliantEntityAudit\\Entity\\RevisionEntity')
                         ->findBy(array(
-                            'targetEntityClass' => get_class($element),
+                            'targetEntityClass' => $this->getEntityClass($element),
                             'entityKeys' => serialize(array('id' => $element->getId())),
                         ), array('id' => 'DESC'), 1);
 
@@ -313,5 +315,15 @@ class LogRevision implements EventSubscriber
             $this->resetRevisionEntities();
             $this->setInAuditTransaction(false);
         }
+    }
+
+    /**
+     * @param $entity
+     * @return string
+     */
+    private function getEntityClass($entity)
+    {
+        $entityClass = get_class($entity);
+        return $entityClass;
     }
 }

--- a/src/SoliantEntityAudit/EventListener/LogRevision.php
+++ b/src/SoliantEntityAudit/EventListener/LogRevision.php
@@ -225,8 +225,8 @@ class LogRevision implements EventSubscriber
         }
 
         foreach ($eventArgs->getEntityManager()->getUnitOfWork()->getScheduledEntityDeletions() AS $entity) {
-            if (!$moduleOptions->getSoftDeletableInterface()
-                || !in_array($moduleOptions->getSoftDeletableInterface(), class_implements($entity))
+            if (!$moduleOptions->getSoftDeletableInterfaceName()
+                || !in_array($moduleOptions->getSoftDeletableInterfaceName(), class_implements($entity))
             ) {
                 $entities = array_merge($entities, $this->auditEntity($entity, 'DEL'));
             }

--- a/src/SoliantEntityAudit/EventListener/LogRevision.php
+++ b/src/SoliantEntityAudit/EventListener/LogRevision.php
@@ -276,10 +276,17 @@ class LogRevision implements EventSubscriber
 
                 $joinClassName = "SoliantEntityAudit\\Entity\\" . str_replace('\\', '_', $mapping['joinTable']['name']);
                 $moduleOptions->addJoinClass($joinClassName, $mapping);
+                $revisionEntity = null;
 
                 foreach ($this->many2many as $map) {
-                    if ($map['collection'] == $value)
+                    if ($map['collection'] == $value){
                         $revisionEntity = $map['revisionEntity'];
+                        break;
+                    }
+                }
+
+                if (!$revisionEntity) {
+                    continue;
                 }
 
                 foreach ($value->getSnapshot() as $element) {

--- a/src/SoliantEntityAudit/Loader/AuditAutoloader.php
+++ b/src/SoliantEntityAudit/Loader/AuditAutoloader.php
@@ -166,18 +166,23 @@ class AuditAutoloader extends StandardAutoloader
 
         $auditClass->setNamespaceName("SoliantEntityAudit\\Entity");
         $auditClass->setName(str_replace('\\', '_', $currentClass));
-        $auditClass->setExtendedClass('AbstractAudit');
 
-        #    $auditedClassMetadata = $metadataFactory->getMetadataFor($currentClass);
-        $auditedClassMetadata = $metadataFactory->getMetadataFor($currentClass);
+        // $auditedClassMetadata = $metadataFactory->getMetadataFor($currentClass);
 
-            foreach ($auditedClassMetadata->getAssociationMappings() as $mapping) {
-                if (isset($mapping['joinTable']['name'])) {
-                    $auditJoinTableClassName = "SoliantEntityAudit\\Entity\\" . str_replace('\\', '_', $mapping['joinTable']['name']);
-                    $auditEntities[] = $auditJoinTableClassName;
-                    $moduleOptions->addJoinClass($auditJoinTableClassName, $mapping);
-                }
+        if ($auditedClassMetadata->parentClasses) {
+            $auditClass->setExtendedClass(str_replace('\\', '_', array_pop($auditedClassMetadata->parentClasses)));
+
+        } else {
+            $auditClass->setExtendedClass('AbstractAudit');
+        }
+
+        foreach ($auditedClassMetadata->getAssociationMappings() as $mapping) {
+            if (isset($mapping['joinTable']['name'])) {
+                $auditJoinTableClassName = "SoliantEntityAudit\\Entity\\" . str_replace('\\', '_', $mapping['joinTable']['name']);
+                $auditEntities[] = $auditJoinTableClassName;
+                $moduleOptions->addJoinClass($auditJoinTableClassName, $mapping);
             }
+        }
 
 #        if ($auditClass->getName() == 'AppleConnect_Entity_UserAuthenticationLog') {
 #            echo '<pre>';

--- a/src/SoliantEntityAudit/Mapping/Driver/AuditDriver.php
+++ b/src/SoliantEntityAudit/Mapping/Driver/AuditDriver.php
@@ -98,8 +98,9 @@ final class AuditDriver implements MappingDriver
                 $fieldMapping['nullable'] = true;
                 $fieldMapping['quoted'] = true;
                 $builder->addField($fieldName, $auditedClassMetadata->getTypeOfField($fieldName), $fieldMapping);
-                if ($auditedClassMetadata->isIdentifier($fieldName)) $identifiers[] = $fieldName;
             }
+
+            if ($auditedClassMetadata->isIdentifier($fieldName)) $identifiers[] = $fieldName;
         }
 
         foreach ($auditedClassMetadata->getAssociationMappings() as $mapping) {

--- a/src/SoliantEntityAudit/Mapping/Driver/AuditDriver.php
+++ b/src/SoliantEntityAudit/Mapping/Driver/AuditDriver.php
@@ -103,7 +103,7 @@ final class AuditDriver implements MappingDriver
         }
 
         foreach ($auditedClassMetadata->getAssociationMappings() as $mapping) {
-            if (! isset($fieldMapping['inherited']) && ! isset($fieldMapping['declared'])) {
+            if (! isset($mapping['inherited']) && ! isset($mapping['declared'])) {
                 if (!$mapping['isOwningSide']) continue;
 
                 if (isset($mapping['joinTable'])) {

--- a/src/SoliantEntityAudit/Options/ModuleOptions.php
+++ b/src/SoliantEntityAudit/Options/ModuleOptions.php
@@ -191,7 +191,7 @@ class ModuleOptions
     }
 
     /**
-     * @param string $softDeletableInterface
+     * @param string $softDeletableInterfaceName
      */
     public function setSoftDeletableInterfaceName($softDeletableInterfaceName)
     {

--- a/src/SoliantEntityAudit/Options/ModuleOptions.php
+++ b/src/SoliantEntityAudit/Options/ModuleOptions.php
@@ -18,6 +18,7 @@ class ModuleOptions
     private $auditService;
     private $userEntityClassName;
     private $authenticationService;
+    private $softDeletableInterfaceName;
 
     public function setDefaults(array $config)
     {
@@ -29,6 +30,7 @@ class ModuleOptions
         $this->setRevisionEntityTableName(isset($config['revisionEntityTableName']) ? $config['revisionEntityTableName']: 'RevisionEntity');
         $this->setUserEntityClassName(isset($config['userEntityClassName']) ? $config['userEntityClassName']: 'ZfcUserDoctrineORM\\Entity\\User');
         $this->setAuthenticationService(isset($config['authenticationService']) ? $config['authenticationService']: 'zfcuser_auth_service');
+        $this->setSoftDeletableInterfaceName(isset($config['softDeletableInterfaceName']) ? $config['softDeletableInterfaceName']: '');
     }
 
     public function getAuditService()
@@ -178,5 +180,21 @@ class ModuleOptions
     public function getUser()
     {
         return $this->user;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSoftDeletableInterfaceName()
+    {
+        return $this->softDeletableInterfaceName;
+    }
+
+    /**
+     * @param string $softDeletableInterface
+     */
+    public function setSoftDeletableInterfaceName($softDeletableInterfaceName)
+    {
+        $this->softDeletableInterfaceName = $softDeletableInterfaceName;
     }
 }


### PR DESCRIPTION
Currently, inheritance is not managed properly. This PR enables at least Single Table Inheritance. When using this, discriminator map must be specified explicitly. If not specified, and therefore discovered at schema generation, schema generation tool enters an infinite loop. Joined Table Inheritance is not tested, but might work.
